### PR TITLE
feature/current-season-data

### DIFF
--- a/models/Show/index.js
+++ b/models/Show/index.js
@@ -36,6 +36,15 @@ const typeDef = gql`
     cast: [Cast]
     crew: [Crew]
     videos: [Video]
+    current_season: CurrentSeason
+  }
+
+  type CurrentSeason {
+    image: String
+    season_number: Int
+    year: String
+    episode_count: Int
+    overview: String
   }
 
   type Shows {

--- a/resolvers/Videos/ShowResolver.js
+++ b/resolvers/Videos/ShowResolver.js
@@ -1,5 +1,5 @@
 const axios = require("axios");
-const { filter } = require("lodash");
+const { filter, forEach } = require("lodash");
 
 const { generateVideoEndpoint } = require("../../utils/generateEndpoints");
 


### PR DESCRIPTION
**As part of this PR I have completed the following:**

- Added support for a new object, this provides the current season information

- The fields added are the following: image, year, episode_count and overview (See why [here ](https://www.themoviedb.org/tv/71446-la-casa-de-papel).

- Removed uneeded formatting, we no longer need to format both the last_episode_to_air and seasons, instead we only format what we need for the front-end.

- Fixed a TV video resolver issue.